### PR TITLE
Fix `priority-queue.adoc` broken link

### DIFF
--- a/docs/modules/data-structures/pages/priority-queue.adoc
+++ b/docs/modules/data-structures/pages/priority-queue.adoc
@@ -5,7 +5,7 @@ Items in this queue do not necessarily follow the FIFO or LIFO order;
 you assign a comparator which defines the order in which items will be stored in the queue.
 Items with higher priority get polled first, regardless of when they have been added.
 
-Its configuration is same as the regular queue as explained in <<configuring-queue>>
+Its configuration is same as the regular queue as explained in xref:data-structures:queue.adoc#configuring-queue[]
 except the additional comparator configuration element. A declarative example
 is shown below:
 


### PR DESCRIPTION
[Production docs](https://docs.hazelcast.com/hazelcast/latest/data-structures/priority-queue#configuring-queue) show:
<img width="1313" alt="image" src="https://github.com/user-attachments/assets/1a16073a-8943-4560-98e2-30f54b700635" />
